### PR TITLE
Feature: Deploy model to GCP via Cloud Run (& alternative Vertex AI)

### DIFF
--- a/.github/workflows/cd-cloudrun.yml
+++ b/.github/workflows/cd-cloudrun.yml
@@ -1,0 +1,47 @@
+name: "Continuous Delivery (Cloud Run)"
+
+on:
+  push:
+    branches:
+      - feature/deploy
+
+env:
+  PROJECT_ID: latam-challenge-448714
+  LOCATION: us-central1
+  GAR_REPO: latam-images
+  APP: delay-model
+
+jobs:
+  deploy:
+    # Add 'id-token' with the intended permissions for workload identity federation
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "${{ env.PROJECT_ID }}"
+          workload_identity_provider: "projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo"
+
+      - uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 363.0.0"
+
+      - name: "Docker auth"
+        run: |-
+          gcloud auth configure-docker ${{ env.LOCATION }}-docker.pkg.dev
+
+      - name: "Build and push container"
+        run: |-
+          docker build -t "${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
+          docker push "${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+
+      - name: "Deploy to Cloud Run"
+        uses: "google-github-actions/deploy-cloudrun@v2"
+        with:
+          service: "latam-challenge"
+          image: "${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,42 @@
+name: 'Continuous Delivery'
+
+on:
+  push:
+    branches:
+      - feature/deploy
+
+env:
+  PROJECT_ID: latam-challenge-448714
+#   GAR_LOCATION: YOUR_GAR_LOCATION # TODO: update Artifact Registry location
+#   REGION: YOUR_APP_REGION # TODO: update Cloud Run service region
+#   APP: app
+
+jobs:
+  deploy:
+    # Add 'id-token' with the intended permissions for workload identity federation
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+        - uses: 'actions/checkout@v4'
+
+        - uses: 'google-github-actions/auth@v2'
+          with:
+            project_id: '${{ env.PROJECT_ID }}'
+            workload_identity_provider: 'projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo'
+
+      # - name: 'Set up Cloud SDK'
+      #   uses: 'google-github-actions/setup-gcloud@v1'
+      #   with:
+      #     project_id: '${{ env.PROJECT_ID }}'
+
+      # - name: 'Docker auth'
+      #   run: |-
+      #     gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
+
+      # - name: 'Build and push container'
+      #   run: |-
+      #     docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}" ./app
+      #     docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,9 +7,10 @@ on:
 
 env:
   PROJECT_ID: latam-challenge-448714
-#   GAR_LOCATION: YOUR_GAR_LOCATION # TODO: update Artifact Registry location
+  GAR_LOCATION: us-centrail1
+  GAR_REPO: latam-images
+  APP: delay-model
 #   REGION: YOUR_APP_REGION # TODO: update Cloud Run service region
-#   APP: app
 
 jobs:
   deploy:
@@ -27,24 +28,15 @@ jobs:
             project_id: '${{ env.PROJECT_ID }}'
             workload_identity_provider: 'projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo'
 
-        - name: 'Set up Cloud SDK'
-          uses: 'google-github-actions/setup-gcloud@v2'
+        - uses: 'google-github-actions/setup-gcloud@v2'
           with:
             version: '>= 363.0.0'
 
-        - name: 'Use gcloud CLI'
-          run: 'gcloud info'
+        - name: 'Docker auth'
+          run: |-
+            gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-      # - name: 'Set up Cloud SDK'
-      #   uses: 'google-github-actions/setup-gcloud@v1'
-      #   with:
-      #     project_id: '${{ env.PROJECT_ID }}'
-
-      # - name: 'Docker auth'
-      #   run: |-
-      #     gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
-
-      # - name: 'Build and push container'
-      #   run: |-
-      #     docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}" ./app
-      #     docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}"
+        - name: 'Build and push container'
+          run: |-
+            docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
+            docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,14 @@ jobs:
             project_id: '${{ env.PROJECT_ID }}'
             workload_identity_provider: 'projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo'
 
+        - name: 'Set up Cloud SDK'
+          uses: 'google-github-actions/setup-gcloud@v2'
+          with:
+            version: '>= 363.0.0'
+
+        - name: 'Use gcloud CLI'
+          run: 'gcloud info'
+
       # - name: 'Set up Cloud SDK'
       #   uses: 'google-github-actions/setup-gcloud@v1'
       #   with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,3 +40,7 @@ jobs:
           run: |-
             docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
             docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+
+        - name: 'Deploy model'
+          run: gcloud ai models upload -region=us-central1 --display-name=${{ env.APP }} --artifact-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,43 +36,48 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-      - name: "Pull latest image"
-        run: >
-          docker pull
-          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+      # - name: "Pull latest image"
+      #   run: >
+      #     docker pull
+      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
 
       - name: "Build image"
         run: >
           docker build 
           -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
           --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
           .
 
       - name: "Push image"
-        run: docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+        run: >
+          docker push 
+          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}"
+          --all-tags
+
 
       # - name: 'Build and push container'
       #   run: |-
       #     docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
       #     docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
-      - name: "Upload model"
-        run: >
-          gcloud ai models upload
-          --region=us-central1
-          --display-name=${{ env.APP }} 
-          --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
-          --container-health-route /health 
-          --container-predict-route /predict 
-          --model-id delay-model 
-          --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
-          --version-aliases default
+      # - name: "Upload model"
+      #   run: >
+      #     gcloud ai models upload
+      #     --region=us-central1
+      #     --display-name=${{ env.APP }} 
+      #     --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
+      #     --container-health-route /health 
+      #     --container-predict-route /predict 
+      #     --model-id delay-model 
+      #     --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
+      #     --version-aliases default
 
-      - name: "Deploy model"
-        run: >
-          gcloud ai endpoints deploy-model 
-          delay-model-endpoint 
-          --project="latam-challenge-448714" 
-          --region=us-central1 
-          --model=delay-model 
-          --display-name=delay-model-deployed
+      # - name: "Deploy model"
+      #   run: >
+      #     gcloud ai endpoints deploy-model 
+      #     delay-model-endpoint 
+      #     --project="latam-challenge-448714" 
+      #     --region=us-central1 
+      #     --model=delay-model 
+      #     --display-name=delay-model-deployed

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,30 +36,31 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-      - name: "Pull latest image"
-        run: >
-          docker pull
-          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+      # - name: "Pull latest image"
+      #   run: >
+      #     docker pull
+      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
 
-      - name: "Build image"
-        run: >
-          docker build 
-          -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
-          -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-          --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-          .
+      # - name: "Build image"
+      #   run: >
+      #     docker build 
+      #     -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+      #     -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+      #     --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+      #     .
 
-      - name: "Push image"
-        run: >
-          docker push 
-          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}"
-          --all-tags
+      # - name: "Push image"
+      #   run: >
+      #     docker push 
+      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}"
+      #     --all-tags
 
 
-      # - name: 'Build and push container'
-      #   run: |-
-      #     docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
-      #     docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+      - name: 'Pull, Build and push container'
+        run: |-
+          docker pull "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest" --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest" .
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}" --all-tags
 
       # - name: "Upload model"
       #   run: >

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PROJECT_ID: latam-challenge-448714
-  GAR_LOCATION: us-centrail1
+  GAR_LOCATION: us-central1
   GAR_REPO: latam-images
   APP: delay-model
 #   REGION: YOUR_APP_REGION # TODO: update Cloud Run service region

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ env:
   GAR_LOCATION: us-central1
   GAR_REPO: latam-images
   APP: delay-model
+  VERTEX_ENDPOINT_ID: 7896596853175615488
 
 jobs:
   deploy:
@@ -55,29 +56,31 @@ jobs:
       #     --all-tags
 
 
-      - name: 'Pull, Build and push container'
+      - name: 'Build and push container'
         run: |-
-          docker pull "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest" --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest" .
-          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}" --all-tags
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
-      # - name: "Upload model"
-      #   run: >
-      #     gcloud ai models upload
-      #     --region=us-central1
-      #     --display-name=${{ env.APP }} 
-      #     --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
-      #     --container-health-route /health 
-      #     --container-predict-route /predict 
-      #     --model-id delay-model 
-      #     --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
-      #     --version-aliases default
+      - name: "Upload model"
+        run: >
+          gcloud ai models upload
+          --region=us-central1
+          --display-name=${{ env.APP }} 
+          --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
+          --container-health-route /health 
+          --container-predict-route /predict 
+          --model-id delay-model 
+          --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
+          --version-aliases default
 
-      # - name: "Deploy model"
-      #   run: >
-      #     gcloud ai endpoints deploy-model 
-      #     delay-model-endpoint 
-      #     --project="latam-challenge-448714" 
-      #     --region=us-central1 
-      #     --model=delay-model 
-      #     --display-name=delay-model-deployed
+      - name: "Deploy model"
+        run: >
+          gcloud ai endpoints deploy-model 
+          delay-model-endpoint 
+          --project="latam-challenge-448714" 
+          --region=us-central1 
+          --model=delay-model 
+          --display-name=delay-model-deployed
+          --min-replica-count=1
+          --max-replica-count=2
+          --traffic-split=0=100

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,5 +42,5 @@ jobs:
             docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
         - name: 'Deploy model'
-          run: gcloud ai models upload -region=us-central1 --display-name=${{ env.APP }} --artifact-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --artifact-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: 'Continuous Delivery'
+name: "Continuous Delivery"
 
 on:
   push:
@@ -16,34 +16,63 @@ jobs:
   deploy:
     # Add 'id-token' with the intended permissions for workload identity federation
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
     runs-on: ubuntu-latest
     steps:
-        - uses: 'actions/checkout@v4'
+      - uses: "actions/checkout@v4"
 
-        - uses: 'google-github-actions/auth@v2'
-          with:
-            project_id: '${{ env.PROJECT_ID }}'
-            workload_identity_provider: 'projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo'
+      - uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "${{ env.PROJECT_ID }}"
+          workload_identity_provider: "projects/831127518569/locations/global/workloadIdentityPools/github/providers/my-repo"
 
-        - uses: 'google-github-actions/setup-gcloud@v2'
-          with:
-            version: '>= 363.0.0'
+      - uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 363.0.0"
 
-        - name: 'Docker auth'
-          run: |-
-            gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
+      - name: "Docker auth"
+        run: |-
+          gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-        - name: 'Build and push container'
-          run: |-
-            docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
-            docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+      - name: "Pull latest image"
+        run: >
+          docker pull
+          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
 
-        - name: 'Upload model'
-          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" --container-health-route /health --container-predict-route /predict --model-id delay-model --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model --version-aliases default
+      - name: "Build image"
+        run: >
+          docker build 
+          -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+          .
 
-        - name: 'Deploy model'
-          run: gcloud ai endpoints deploy-model delay-model-endpoint --project="latam-challenge-448714" --region=us-central1 --model=delay-model --display-name=delay-model-deployed
+      - name: "Push image"
+        run: docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
+      # - name: 'Build and push container'
+      #   run: |-
+      #     docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
+      #     docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+
+      - name: "Upload model"
+        run: >
+          gcloud ai models upload
+          --region=us-central1
+          --display-name=${{ env.APP }} 
+          --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
+          --container-health-route /health 
+          --container-predict-route /predict 
+          --model-id delay-model 
+          --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
+          --version-aliases default
+
+      - name: "Deploy model"
+        run: >
+          gcloud ai endpoints deploy-model 
+          delay-model-endpoint 
+          --project="latam-challenge-448714" 
+          --region=us-central1 
+          --model=delay-model 
+          --display-name=delay-model-deployed

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,6 @@ env:
   GAR_LOCATION: us-central1
   GAR_REPO: latam-images
   APP: delay-model
-  VERTEX_ENDPOINT_ID: 7896596853175615488
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
             docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
         - name: 'Upload model'
-          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" --model-id delay-model --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model --version-aliases default
+          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" --container-health-route /health --container-predict-route /predict --model-id delay-model --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model --version-aliases default
 
         - name: 'Deploy model'
           run: gcloud ai endpoints deploy-model delay-model-endpoint --project="latam-challenge-448714" --region=us-central1 --model=delay-model --display-name=delay-model-deployed

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,10 +36,10 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
 
-      # - name: "Pull latest image"
-      #   run: >
-      #     docker pull
-      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
+      - name: "Pull latest image"
+        run: >
+          docker pull
+          "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
 
       - name: "Build image"
         run: >

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,5 +42,5 @@ jobs:
             docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
         - name: 'Deploy model'
-          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --artifact-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: "Continuous Delivery (Vertex Model Registry + Endpoint)"
 on:
   push:
     branches:
-      - feature/deploy
+      - main
 
 env:
   PROJECT_ID: latam-challenge-448714

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: "Continuous Delivery"
+name: "Continuous Delivery (Vertex Model Registry + Endpoint)"
 
 on:
   push:
@@ -7,10 +7,9 @@ on:
 
 env:
   PROJECT_ID: latam-challenge-448714
-  GAR_LOCATION: us-central1
+  LOCATION: us-central1
   GAR_REPO: latam-images
   APP: delay-model
-  VERTEX_ENDPOINT_ID: 7896596853175615488
 
 jobs:
   deploy:
@@ -34,53 +33,33 @@ jobs:
 
       - name: "Docker auth"
         run: |-
-          gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          gcloud auth configure-docker ${{ env.LOCATION }}-docker.pkg.dev
 
-      # - name: "Pull latest image"
-      #   run: >
-      #     docker pull
-      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-
-      # - name: "Build image"
-      #   run: >
-      #     docker build 
-      #     -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
-      #     -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-      #     --cache-from "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:latest"
-      #     .
-
-      # - name: "Push image"
-      #   run: >
-      #     docker push 
-      #     "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}"
-      #     --all-tags
-
-
-      - name: 'Build and push container'
+      - name: "Build and push container"
         run: |-
-          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
-          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          docker build -t "${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
+          docker push "${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
       - name: "Upload model"
         run: >
           gcloud ai models upload
-          --region=us-central1
+          --region=${{ env.LOCATION }}
           --display-name=${{ env.APP }} 
-          --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
+          --container-image-uri="${{ env.LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" 
           --container-health-route /health 
           --container-predict-route /predict 
-          --model-id delay-model 
-          --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model 
+          --model-id ${{ env.APP }}
+          --parent-model projects/${{ env.PROJECT_ID }}/locations/${{ env.LOCATION }}/models/${{ env.APP }}
           --version-aliases default
 
       - name: "Deploy model"
         run: >
           gcloud ai endpoints deploy-model 
-          delay-model-endpoint 
-          --project="latam-challenge-448714" 
-          --region=us-central1 
-          --model=delay-model 
-          --display-name=delay-model-deployed
+          ${{ env.APP }}-endpoint 
+          --project=${{ env.PROJECT_ID }}
+          --region=${{ env.LOCATION }}
+          --model=${{ env.APP }} 
+          --display-name=${{ env.APP }}-deployed
           --min-replica-count=1
           --max-replica-count=2
           --traffic-split=0=100

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ env:
   GAR_LOCATION: us-central1
   GAR_REPO: latam-images
   APP: delay-model
-#   REGION: YOUR_APP_REGION # TODO: update Cloud Run service region
+  VERTEX_ENDPOINT_ID: 7896596853175615488
 
 jobs:
   deploy:
@@ -41,6 +41,9 @@ jobs:
             docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" .
             docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
 
+        - name: 'Upload model'
+          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}" --model-id delay-model --parent-model projects/latam-challenge-448714/locations/us-central1/models/delay-model --version-aliases default
+
         - name: 'Deploy model'
-          run: gcloud ai models upload --region=us-central1 --display-name=${{ env.APP }} --container-image-uri="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.GAR_REPO }}/${{ env.APP }}:${{ github.sha }}"
+          run: gcloud ai endpoints deploy-model delay-model-endpoint --project="latam-challenge-448714" --region=us-central1 --model=delay-model --display-name=delay-model-deployed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
 # syntax=docker/dockerfile:1.2
-FROM python:latest
-# put you docker configuration here
+FROM python:3.13
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache-dir .
+
+CMD ["fastapi", "run", "challenge/api.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 RUN pip install --no-cache-dir .
 
-CMD ["fastapi", "run", "challenge/api.py"]
+CMD ["fastapi", "run", "--port", "8080", "challenge/api.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 
 COPY requirements.txt requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY . .
-RUN pip install --no-cache-dir .
+RUN pip install .
 
 CMD ["fastapi", "run", "--port", "8080", "challenge/api.py"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:		## Install dependencies
 	pip install -r requirements-test.txt
 	pip install -r requirements.txt
 
-STRESS_URL = http://127.0.0.1:8000 
+STRESS_URL = https://latam-challenge-831127518569.us-central1.run.app
 .PHONY: stress-test
 stress-test:
 	# change stress url to your deployed app 


### PR DESCRIPTION
## Description

This PR deploys the model in GCP.

- Two ways of deploying were proposed.
- The first one tried was using Vertex Model Registry + Vertex Endpoints. The workflow on cd.yml implements this. A Vertex Endpoint was created, and the CD workflow uploaded a new model to then be deployed to that endpoint, making the traffic to point to the newer version of the model each time. A problem with this approach (for the purposes of this challenge) is that the requests to the model requires to be authenticated ones. Another contra to this approach is that re-deploying takes longer (as you can check in the history of Actions of this repo). This workflow was disabled for now.
- The second approach is simpler. Just use Cloud Run, which allows easily for non-authenticated requests. Also, the re-deploy takes much less time.